### PR TITLE
feat:To make ipcRenderer work

### DIFF
--- a/packages/crale-electron/package.json
+++ b/packages/crale-electron/package.json
@@ -10,7 +10,7 @@
     "build": "electron-webpack",
     "electron": "electron dist/main/main.js",
     "package": "electron-builder",
-    "start": "electron-webpack dev",
+    "start": "node ./scripts/start.js",
     "test": "echo Skipped."
   },
   "dependencies": {

--- a/packages/crale-electron/scripts/start.js
+++ b/packages/crale-electron/scripts/start.js
@@ -1,0 +1,19 @@
+const { Socket } = require("net");
+const { exec } = require("child_process");
+const client = new Socket();
+
+const port = 3000;
+let started = false;
+
+const tryConnection = () =>   
+  client.connect({ port: port }, () => {
+    if (!started) {
+      console.log("Electron is waiting...");
+      started = true;
+      exec("yarn electron-webpack dev").stdout.on("data", data => console.log(data.toString()));
+    }
+  });
+
+client.on("error", () => setTimeout(tryConnection, 1000));
+
+tryConnection();

--- a/packages/crale-electron/src/main/index.ts
+++ b/packages/crale-electron/src/main/index.ts
@@ -17,7 +17,7 @@ const createMainWindow = () => {
     width: 800,
     height: 600,
     webPreferences: {
-      nodeIntegration: true,
+      nodeIntegration: false,
       preload: path.join(staticPath, 'preload.js')
     }
   });

--- a/packages/crale-electron/static/preload.js
+++ b/packages/crale-electron/static/preload.js
@@ -1,5 +1,5 @@
 const { ipcRenderer, remote } = require('electron');
 
 if (remote) {
-  window.ipc = ipcRenderer;
+  window.ipcRenderer = ipcRenderer;
 }

--- a/packages/crale-electron/static/preload.js
+++ b/packages/crale-electron/static/preload.js
@@ -1,0 +1,5 @@
+const { ipcRenderer, remote } = require('electron');
+
+if (remote) {
+  window.ipc = ipcRenderer;
+}

--- a/packages/crale-react/src/App.tsx
+++ b/packages/crale-react/src/App.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 
+import ipc from './ipc';
+
 function App() {
   return (
     <div className="App">
@@ -19,6 +21,17 @@ function App() {
         >
           Learn React
         </a>
+
+        <button
+          className="hello-electron mt-5"
+          onClick={() => {
+            ipc?.send('hello-electron', {
+              message: 'This is react!'
+            });
+          }}
+        >
+          Hi Electron!
+        </button>
       </header>
     </div>
   );

--- a/packages/crale-react/src/index.css
+++ b/packages/crale-react/src/index.css
@@ -1,13 +1,40 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+}
+
+.hello-electron {
+  display: block;
+  font-weight: 400;
+  color: #fff;
+  text-align: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-color: transparent;
+  border: 1px solid #fff;
+  padding: 0.375rem 7.75rem;
+  margin: 0 auto;
+  font-size: 1rem;
+  line-height: 1.5;
+  border-radius: 0.25rem;
+}
+
+.hello-electron:hover {
+  background-color: #ffffff1c;
+  cursor: pointer;
+}
+
+.mt-5 {
+  margin-top: 3rem;
 }

--- a/packages/crale-react/src/ipc.ts
+++ b/packages/crale-react/src/ipc.ts
@@ -1,0 +1,9 @@
+const ipc: IpcRenderer | undefined = window.ipcRenderer;
+
+// make sure console get a warning when ipc is undefined,
+// obviously it won't work in actual broser
+if (ipc === undefined) {
+  console.log('IpcRenderer is not available here.');
+}
+
+export default ipc;

--- a/packages/crale-react/src/react-app-env.d.ts
+++ b/packages/crale-react/src/react-app-env.d.ts
@@ -1,1 +1,83 @@
 /// <reference types="react-scripts" />
+
+interface Window {
+  /**
+   * Electron IPC (inter-process communication) for render process, which is
+   * injected to window object by preload property in BrowserWindow from electron.
+   * And won't work in a actual brower, so it may be undefined.
+   */
+  ipcRenderer: IpcRenderer | undefined;
+}
+
+interface IpcRenderer extends NodeJS.EventEmitter {
+  // Docs: http://electronjs.org/docs/api/ipc-renderer
+
+  /**
+   * Resolves with the response from the main process.
+   *
+   * Send a message to the main process asynchronously via `channel` and expect an
+   * asynchronous result. Arguments will be serialized as JSON internally and hence
+   * no functions or prototype chain will be included.
+   *
+   * The main process should listen for `channel` with `ipcMain.handle()`.
+   *
+   */
+  invoke(channel: string, ...args: any[]): Promise<any>;
+  /**
+   * Listens to `channel`, when a new message arrives `listener` would be called with
+   * `listener(event, args...)`.
+   */
+  on(
+    channel: string,
+    listener: (event: IpcRendererEvent, ...args: any[]) => void
+  ): this;
+  /**
+   * Adds a one time `listener` function for the event. This `listener` is invoked
+   * only the next time a message is sent to `channel`, after which it is removed.
+   */
+  once(
+    channel: string,
+    listener: (event: IpcRendererEvent, ...args: any[]) => void
+  ): this;
+  /**
+   * Removes all listeners, or those of the specified `channel`.
+   */
+  removeAllListeners(channel: string): this;
+  /**
+   * Removes the specified `listener` from the listener array for the specified
+   * `channel`.
+   */
+  removeListener(channel: string, listener: (...args: any[]) => void): this;
+  /**
+   * Send a message to the main process asynchronously via `channel`, you can also
+   * send arbitrary arguments. Arguments will be serialized as JSON internally and
+   * hence no functions or prototype chain will be included.
+   *
+   * The main process handles it by listening for `channel` with the `ipcMain`
+   * module.
+   */
+  send(channel: string, ...args: any[]): void;
+  /**
+   * The value sent back by the `ipcMain` handler.
+   *
+   * Send a message to the main process synchronously via `channel`, you can also
+   * send arbitrary arguments. Arguments will be serialized in JSON internally and
+   * hence no functions or prototype chain will be included.
+   *
+   * The main process handles it by listening for `channel` with `ipcMain` module,
+   * and replies by setting `event.returnValue`.
+   *
+   * **Note:** Sending a synchronous message will block the whole renderer process,
+   * unless you know what you are doing you should never use it.
+   */
+  sendSync(channel: string, ...args: any[]): any;
+  /**
+   * Sends a message to a window with `webContentsId` via `channel`.
+   */
+  sendTo(webContentsId: number, channel: string, ...args: any[]): void;
+  /**
+   * Like `ipcRenderer.send` but the event will be sent to the `<webview>` element in
+   * the host page instead of the main process.
+   */
+  sendToHost(channel: string, ...args: any[]): void;
+}


### PR DESCRIPTION
This PR can make ipcRender work in a monorepo.
The main idea is:
* Preload a script, which injects `ipcRenderer` instance into window object of `BrowserWindow`.
```javascript
// preload.js
const { ipcRenderer, remote } = require('electron');

if (remote) {
  window.ipcRenderer = ipcRenderer;
}
```

```typescript
// main process
mainWindow = new BrowserWindow({
    width: 800,
    height: 600,
    webPreferences: {
      nodeIntegration: true,
      preload: path.join(staticPath, 'preload.js')
    }
  });
```
* To make ts file can access `ipcRenderer` in `crale-react`, wo need to make it global by creating a ipcRender property of Window interface.

```typescript
// react-app-env.d.ts
interface Window {
  /**
   * Electron IPC (inter-process communication) for render process, which is
   * injected to window object by preload property in BrowserWindow from electron.
   * And won't work in a actual brower, so it may be undefined.
   */
  ipcRenderer: IpcRenderer | undefined;
}

// and also copy IpcRender interface located in electron.d.ts
interface IpcRenderer extends NodeJS.EventEmitter {
/*........................................................................*/
}
````

* Also, we need a wrap for `window.ipcRender`

```typescript
const ipc: IpcRenderer | undefined = window.ipcRenderer;

// make sure console get a warning when ipc is undefined,
// obviously it won't work in actual broser
if (ipc === undefined) {
  console.log('IpcRenderer is not available here.');
}

export default ipc;
```